### PR TITLE
Docker: link system libffi instead of fetching from GitHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: ci
 on:
   push:
-    branches: ['*']
+    branches: ['**']
     tags-ignore: ['*']
   pull_request:
 jobs:

--- a/Changes
+++ b/Changes
@@ -1,5 +1,13 @@
 {{$NEXT}}
 
+    - Docker: build Alien::FFI against the system libffi (apt libffi-dev) instead
+      of fetching a libffi tarball from a GitHub release page, which broke the
+      image build intermittently in CI (Alien::Build itself warns the
+      release-page download negotiator "will typically not work"). The runtime
+      image now ships libffi8 for the dynamically linked FFI::Platypus. The
+      vendored libgit2 (share) build is unchanged, so the runtime stays
+      self-contained.
+
 0.302     2026-06-21 23:04:42Z
 
     - `karr board` now renders a compact, Markdown-flavoured plaintext board

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,17 @@ FROM perl:5.40-slim AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential cmake pkg-config \
-    libssl-dev zlib1g-dev libssh2-1-dev git \
+    libssl-dev zlib1g-dev libssh2-1-dev libffi-dev git \
     && rm -rf /var/lib/apt/lists/*
 
 COPY . /tmp/karr-src
+
+# Install Alien::FFI against the system libffi (libffi-dev above) up front, so it
+# links the packaged libffi.so instead of fetching a libffi tarball from a GitHub
+# release page — that download is fragile and rate-limited (Alien::Build itself
+# warns the release-page negotiator "will typically not work"), and it is what
+# broke CI builds intermittently.
+RUN ALIEN_INSTALL_TYPE=system cpanm --notest Alien::FFI
 
 # Force Alien::Libgit2 to vendor libgit2 (share build) so the runtime image is
 # self-contained — the slim runtime has no system libgit2 to dynamically link.
@@ -17,11 +24,12 @@ RUN cpanm --notest --installdeps /tmp/karr-src \
 
 FROM perl:5.40-slim AS runtime-base
 
-# git + runtime shared libs the vendored libgit2.so links against
-# (OpenSSL for HTTPS, libssh2 for SSH, zlib for compression).
+# git + runtime shared libs: the vendored libgit2.so links against OpenSSL
+# (HTTPS), libssh2 (SSH) and zlib (compression); FFI::Platypus now links the
+# system libffi (see builder stage), so libffi8 must be present at runtime too.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git gosu passwd \
-    libssl3 libssh2-1 zlib1g \
+    libssl3 libssh2-1 zlib1g libffi8 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/local/lib/perl5/site_perl/ /usr/local/lib/perl5/site_perl/


### PR DESCRIPTION
## Was war kaputt

Der CI-Build von `e7c2e5e` schlug im **Docker-Image-Build** (`@Author::GETTY::Docker`) fehl — **nicht** in den Tests. Die Fehlerkette:

```
Git::Native → Git::Libgit2 → FFI::Platypus → Alien::FFI   ← Building Alien-FFI-0.27 failed
```

Der Commit selbst (`.claude/`-Agent-Struktur) hat weder Code, `cpanfile`, `dist.ini` noch `Dockerfile` angefasst. Beweis: Der grüne Run ~16 h zuvor baute **dieselben** Versionen (`Alien-FFI-0.27`, `FFI-Platypus-2.11`, `Git-Native-0.003`) erfolgreich. Also transient.

## Ursache

Der Docker-`builder` setzt global `ALIEN_INSTALL_TYPE=share`. Das zwingt **auch** `Alien::FFI` in den share-Modus, wo es ein libffi-Tarball von einer **GitHub-Release-Seite** lädt und aus Quellcode baut. Alien::Build warnt selbst:

> It looks like this alien is using the regular download negotiator plugin on a GitHub release page. This will typically not work due to changes in the way GitHub release page works now.

Dieser Download ist rate-limited / unzuverlässig → intermittierende Build-Fehler.

## Fix

- `libffi-dev` im builder ergänzt und `Alien::FFI` vorab mit `ALIEN_INSTALL_TYPE=system` installiert → linkt das System-`libffi`, **kein** GitHub-Download mehr.
- Der `libgit2`-Vendoring-Pfad (`share`) bleibt **unverändert** → runtime bleibt self-contained.
- `libffi8` ins runtime-Image, da `FFI::Platypus` jetzt dynamisch gegen System-`libffi.so` linkt.

## Verifikation

Lokaler Multi-Stage-Build, der den Dockerfile-Aufbau spiegelt:
- `Alien-FFI-0.27` baut in ~1,5 s **ohne** libffi-Fetch (vorher ~30–60 s Source-Build im share-Modus).
- `Alien-Libgit2` baut weiter vendored (~70 s via cmake).
- runtime-Smoke-Test: `perl -MGit::Native` lädt FFI::Platypus + vendored libgit2 + system libffi sauber → **SMOKE OK**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)