### PR TITLE
ci: drop redundant tags-ignore glob

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: ci
 on:
   push:
     branches: ['**']
-    tags-ignore: ['*']
   pull_request:
 jobs:
   test:


### PR DESCRIPTION
Follow-up zu #4.

`branches: ['**']` macht Tags zum *undefined Git ref* — laut GitHubs Filter-Regeln läuft ein `push`-Event dann gar nicht für Tags. Die `dzil release`-Tags (`v0.NNN`) haben also ohnehin nie gebaut.

`tags-ignore: ['*']` war damit:
1. **redundant** — Tag-Pushes triggern mit definiertem `branches` sowieso nicht;
2. **subtil falsch** — es schaltet die Tag-Auswertung wieder ein, und `['*']` matcht keine Slash-Tags (z.B. `releases/1.0`), die dann doch gebaut hätten.

Entfernt. Verhalten danach: Branch-Pushes + PRs bauen, **alle** Tag-Pushes bauen nicht — ohne Glob-Sonderfall.

> Offizielle Doku: *"If you define only `tags`/`tags-ignore` or only `branches`/`branches-ignore`, the workflow won't run for events affecting the undefined Git ref."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)